### PR TITLE
Modify language update routes to include name of language

### DIFF
--- a/models/language.js
+++ b/models/language.js
@@ -44,10 +44,14 @@ class Language {
 
   static async editLearning({ code, level, id }) {
     const result = await db.query(
-      `UPDATE learning_languages
+      `WITH update AS (UPDATE learning_languages
       SET language_code=$1, level=$2
       WHERE id = $3
-      RETURNING id, language_code AS "code", level`,
+      RETURNING *)
+      SELECT update.id, update.language_code AS "code", update.level, lang.name AS "language"
+      FROM update
+      JOIN languages as lang ON update.language_code = lang.code
+       `,
       [code, level, id]
     );
     const language = result.rows[0];
@@ -61,10 +65,13 @@ class Language {
 
   static async editSpeaks({ code, id }) {
     const result = await db.query(
-      `UPDATE speaks_languages
+      `WITH update AS (UPDATE speaks_languages
       SET language_code=$1
       WHERE id = $2
-      RETURNING id, language_code AS "code"`,
+      RETURNING *)
+      SELECT update.id, update.language_code AS "code", lang.name AS "language"
+      FROM update
+      JOIN languages as lang ON update.language_code = lang.code`,
       [code, id]
     );
     const language = result.rows[0];

--- a/tests/language.test.js
+++ b/tests/language.test.js
@@ -64,6 +64,7 @@ describe("editLearning", function () {
       id: 1,
       code: "es",
       level: 2,
+      language: "Spanish",
     });
   });
 });
@@ -77,6 +78,7 @@ describe("editSpeaks", function () {
     expect(updatedLanguage).toEqual({
       id: 1,
       code: "zh",
+      language: "Chinese",
     });
   });
 });

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -273,7 +273,12 @@ describe("PATCH /languages/learning/:id", function () {
       .patch("/languages/learning/1")
       .send({ code: "de", level: 3 })
       .set("authorization", `Bearer ${testJwt}`);
-    expect(resp.body.language).toEqual({id: 1, code: "de", level: 3});
+    expect(resp.body.language).toEqual({
+      id: 1,
+      code: "de",
+      level: 3,
+      language: "German",
+    });
     expect(resp.status).toEqual(200);
   });
 


### PR DESCRIPTION
Updated to include the name of the language in the response data from:
-  `PATCH /languages/speaks/:id`
-  `PATCH /languages/learning/:id`